### PR TITLE
Updated Elasticsearch data path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports: ['9200:9200']
     networks: ['stack']
     volumes:
-      - ./es_data:/usr/share/elasticsearch/data
+      - ./es_data:/var/lib/elasticsearch/data
     environment:
       - node.name=elasticsearch_ecommerce_01
       - cluster.initial_master_nodes=elasticsearch_ecommerce_01


### PR DESCRIPTION
Updated Elasticsearch data path as the existing one causes an error 'AccessDeniedException[/usr/share/elasticsearch/data/nodes]'. Resolved with this change.